### PR TITLE
update devcontainer to latest ubuntu

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y --no-install-recommends \
     ca-certificates \
     git \
     openssh-client \
+    gnupg \
     build-essential \
     pkg-config \
     cmake \
@@ -16,9 +17,3 @@ RUN apt update && apt install -y --no-install-recommends \
     zip \
     unzip
 
-ARG USERNAME=user
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN groupadd --gid $USER_GID $USERNAME
-RUN useradd --uid $USER_UID --gid $USER_GID -m $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
         "dockerfile": "Dockerfile",
         "context": ".."
     },
-    "remoteUser": "user",
+    "remoteUser": "ubuntu",
     "mounts": [{
         "source": "${localEnv:HOME}/.ssh",
         "target": "/home/user/.ssh",


### PR DESCRIPTION
Since 24.04 ubuntu contains a default user "ubuntu". There is no need to add a default user anymore.